### PR TITLE
fix newlines in browser display

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
     <title>bin.</title>
     <link rel="help" href="https://github.com/w4/bin">
     <style>
@@ -18,6 +17,9 @@
             display: flex;
         }
         body, code, textarea { font-family: Monaco, Menlo, Courier, Courier New, Andale Mono, monospace; }
+        code {
+          display: block;
+        }
         {% block styles %}{% endblock styles %}
     </style>
     {% block head %}{% endblock head %}


### PR DESCRIPTION
Chromium and Firefox don't display newlines correctly

before: ![image](https://user-images.githubusercontent.com/35655527/188304960-84e4b2bf-b03f-4d4d-adaf-7e809436e3b0.png)
after: 
![image](https://user-images.githubusercontent.com/35655527/188304967-232737fe-9cec-4ebd-b9e6-5ee50d6f0526.png)
tested on user agent `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.101 Safari/537.36`

test with
```sh
curl -T - http://127.0.0.1:8820 << EOF
line1
line2
line3
EOF
```