### PR TITLE
show_paste: remove unnecessary path prefix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ struct ShowPaste<'a> {
 
 async fn show_paste(
     req: HttpRequest,
-    key: actix_web::web::Path<String>,
+    key: web::Path<String>,
     plaintext: IsPlaintextRequest,
     store: Data<PasteStore>,
 ) -> Result<HttpResponse, Error> {


### PR DESCRIPTION
The `actix_web::` prefix is not really required for the type of the parameter `key` in the function `show_paste`.