### PR TITLE
use static linking in Dockerfile; add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  bin:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
Hi!
Great project! While I do like nix, I have all my server stuff managed using docker at the moment and want to keep it consistent. I had some issues with the included Dockerfile, as it kept giving me glibc errors.
To circumvent that, I just made it compile statically linked, and it seems to work now.

I also added a very basic docker-compose.yml, so people can just clone the repo and use `docker compose up -d` to get everything up and running.