### PR TITLE
Spacing adjustments

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
             padding: 2rem;
             background: #263238;
             color: #B0BEC5;
-            line-height: 1.1;
+            line-height: 1.4;
             display: flex;
         }
         body, code, textarea { font-family: monospace; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
         background: none;
         border: none;
         outline: 0;
+        padding: 0;
 
         resize: none;
         overflow: auto;

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -18,7 +18,7 @@
         content: counter(line);
         display: inline-block;
         width: 2em; /* Fixed width */
-        padding: 0 1em 0.3em 0;
+        padding: 0 1em 0 0;
         margin-right: .5em;
         color: #888;
         -webkit-user-select: none;


### PR DESCRIPTION
The main goal for this PR is to make the line height uniform between the paste submission page & the display page. For example, here's how they are different now:

<img width="195" alt="image" src="https://github.com/w4/bin/assets/355889/cb5fe8b2-8c15-41ed-83f3-c76395dd10db">
<img width="209" alt="image" src="https://github.com/w4/bin/assets/355889/5131264b-55cb-4942-a396-0f34651bcf1e">

The paste display page has a much higher line-height.

In the version submitted in this PR, they are identical, which IMO looks nicer:

<img width="190" alt="image" src="https://github.com/w4/bin/assets/355889/6e3209dd-32b2-4365-8cfa-7ac5852366a5">
<img width="235" alt="image" src="https://github.com/w4/bin/assets/355889/200e74d4-0db7-4695-89a5-3bc9f2d2a6ee">

Please tell me if you like this.