### PR TITLE
In plaintext mode, end with a newline

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,9 +112,9 @@ async fn submit_raw(
 ) -> Result<String, Error> {
     let id = generate_id();
     let uri = if let Some(Ok(host)) = host.0.as_ref().map(|v| std::str::from_utf8(v.as_bytes())) {
-        format!("https://{host}/{id}")
+        format!("https://{host}/{id}\n")
     } else {
-        format!("/{id}")
+        format!("/{id}\n")
     };
 
     store_paste(&store, id, data);


### PR DESCRIPTION
A curl call like

    curl -X PUT --data-binary @data.txt https://host/

outputs the paste URL without a newline a-la

    https://host/somepastenamewhich can mess up the terminal prompt. I

don't really see the downside of adding a newline. The workflow of

    url="$( curl -X PUT --data-binary @data.txt https://host/ )"
    curl "$url"

still works, since the shell strips the newline in command substitutions.